### PR TITLE
extremely minor cosmetic change

### DIFF
--- a/left4dead2/modes/vendor.txt
+++ b/left4dead2/modes/vendor.txt
@@ -4,9 +4,9 @@
 	"maxplayers" 		"4"
 	"hasdifficulty" 	"1"
 
-		
 	"DisplayTitle"		"Vendor"
 	"Description"		"Eat Pasta"
-	"Image"			"maps/any"
+	"ShortDescription"	"bloody poipe"
+	"Image"			"vgui/maps/any"
 	"Author"		"Waifu Enthusiast"
 }


### PR DESCRIPTION
Added key "ShortDescription" for easier editing later down the road,
Fixed "Image" default file path, now its fancy

Becomes this:
![image](https://user-images.githubusercontent.com/73348166/103454039-ca182300-4d1a-11eb-89c6-bb34eaad3148.png)

Instead of:
![image](https://user-images.githubusercontent.com/73348166/103454061-13687280-4d1b-11eb-8113-a8df1ad5c328.png)

